### PR TITLE
Update cache on node removal

### DIFF
--- a/tube_api.lua
+++ b/tube_api.lua
@@ -161,6 +161,8 @@ local function update_secondary_nodes_after_node_dug(self, pos, dirs)
 			tmp, npos = self:get_secondary_node(pos, dir) 
 		end
 		if npos then
+			self:del_from_cache(npos, Turn180Deg[dir])
+			self:del_from_cache(pos, dir)
 			self:update_secondary_node(npos, Turn180Deg[dir])
 			self:update_secondary_node(pos, dir)
 		end


### PR DESCRIPTION
Fixes #6 

After digging around a bit further on in the chain (`update_secondary_node` onwards) I decided to try finding a simpler solution. Looking at some of the other similar functions I noticed that many of them delete items from cache, after trying this it worked perfectly.

This might not be the ideal solution, let me know