### PR TITLE
Fix side-injection (techpack#85; tubelib#9; bls#294) by checking both dirs for validity instead of assuming second dir will always be valid

### DIFF
--- a/internal2.lua
+++ b/internal2.lua
@@ -163,11 +163,13 @@ function Tube:get_next_tube(pos, dir)
 		local val = Param2ToDir[param2 % 32] or 0
 		local dir1, dir2 = math.floor(val / 10), val % 10
 		local num_conn = math.floor(param2 / 32) or 0
-		if Turn180Deg[dir] == dir1 then
+		local odir = Turn180Deg[dir]
+		if odir == dir1 then
 			return npos, dir2, num_conn
-		else
+		elseif odir == dir2 then
 			return npos, dir1, num_conn
 		end
+		return
 	end
 	return self:get_next_teleport_node(pos, dir)
 end


### PR DESCRIPTION
 Looks like the old logic assumes that if `dir1` is not valid, `dir2` must be.
There is nothing stopping the "next_tube" from being one that is not actually connected to the pushing node, so we must check if `dir2` is actually valid and return `nil` if neither `dir1` or 'dir2` are valid

Fixes https://github.com/joe7575/tubelib2/issues/9
Fixes https://github.com/joe7575/techpack/issues/85
Fixes https://github.com/BlockySurvival/issue-tracker/issues/294