### PR TITLE
Replace deprecated `meta:set_string(*, nil)` calls

### DIFF
--- a/description.txt
+++ b/description.txt
@@ -1,2 +1,0 @@
-A library for mods which need connecting tubes / pipes / cables or similar.
-

--- a/internal1.lua
+++ b/internal1.lua
@@ -135,8 +135,8 @@ end
 function Tube:store_teleport_data(pos, peer_pos)
 	local meta = M(pos)
 	meta:set_string("tele_pos", P2S(peer_pos))
-	meta:set_string("channel", nil)
-	meta:set_string("formspec", nil)
+	meta:set_string("channel", "")
+	meta:set_string("formspec", "")
 	meta:set_string("infotext", S("Paired with @1", P2S(peer_pos)))
 	return meta:get_int("tube_dir")
 end

--- a/internal2.lua
+++ b/internal2.lua
@@ -385,8 +385,8 @@ end
 function Tube:store_teleport_data(pos, peer_pos)
 	local meta = M(pos)
 	meta:set_string("tele_pos", P2S(peer_pos))
-	meta:set_string("channel", nil)
-	meta:set_string("formspec", nil)
+	meta:set_string("channel", "")
+	meta:set_string("formspec", "")
 	meta:set_string("infotext", S("Connected to @1", P2S(peer_pos)))
 	return meta:get_int("tube_dir")
 end

--- a/tube_api.lua
+++ b/tube_api.lua
@@ -455,7 +455,7 @@ function Tube:prepare_pairing(pos, tube_dir, sFormspec)
 		meta:set_int("tube_dir", tube_dir)
 	elseif tube_dir then
 		meta:set_int("tube_dir", tube_dir)
-		meta:set_string("channel", nil)
+		meta:set_string("channel", "")
 		meta:set_string("infotext", S("Pairing is missing"))
 		meta:set_string("formspec", sFormspec)
 	else
@@ -489,8 +489,8 @@ function Tube:stop_pairing(pos, oldmetadata, sFormspec)
 			local peer_meta = M(tele_pos)
 			if peer_meta then
 				self:after_dig_node(tele_pos, {peer_meta:get_int("tube_dir")})
-				peer_meta:set_string("channel", nil)
-				peer_meta:set_string("tele_pos", nil)
+				peer_meta:set_string("channel", "")
+				peer_meta:set_string("tele_pos", "")
 				peer_meta:set_string("formspec", sFormspec)
 				peer_meta:set_string("infotext", S("Pairing is missing"))
 			end


### PR DESCRIPTION
See https://github.com/Archtec-io/bugtracker/issues/190.